### PR TITLE
Crop text outside canvas to increase speed of drawing

### DIFF
--- a/RGBMatrixEmulator/graphics/__init__.py
+++ b/RGBMatrixEmulator/graphics/__init__.py
@@ -11,11 +11,19 @@ def DrawText(canvas, font, x, y, color, text):
     if len(text) == 0:
         return
 
+    # crop text to increase speed dramatically
+    charwidth = int(font.bdf_font.props["cap_height"])
+    if x < 0:
+        adjustment = abs(x + 3) // charwidth
+        text = text[adjustment:]
+        if adjustment:
+            x += charwidth * adjustment
+    if (charwidth * len(text) + x) > canvas.width:
+        text = text[: (canvas.width + 1 // charwidth) + 1]
+
     # Ensure text doesn't get drawn as multiple lines
     linelimit = len(text) * (font.bdf_font.headers['fbbx'] + 1)
 
-    # TODO: This is VERY slow for large text
-    # See mlb-led-scoreboard offday renderer with headlines
     text_map = font.bdf_font.draw(text, linelimit).todata(2)
     font_y_offset = -(font.bdf_font.headers['fbby'] + font.bdf_font.headers['fbbyoff'])
 

--- a/RGBMatrixEmulator/graphics/__init__.py
+++ b/RGBMatrixEmulator/graphics/__init__.py
@@ -14,7 +14,7 @@ def DrawText(canvas, font, x, y, color, text):
     text_orig = text
 
     # crop text to increase speed dramatically
-    charwidth = int(font.bdf_font.props["cap_height"])
+    charwidth = int(font.bdf_font.headers["fbbx"])
     if x < 0:
         adjustment = abs(x + 3) // charwidth
         text = text[adjustment:]

--- a/RGBMatrixEmulator/graphics/__init__.py
+++ b/RGBMatrixEmulator/graphics/__init__.py
@@ -11,6 +11,8 @@ def DrawText(canvas, font, x, y, color, text):
     if len(text) == 0:
         return
 
+    text_orig = text
+
     # crop text to increase speed dramatically
     charwidth = int(font.bdf_font.props["cap_height"])
     if x < 0:
@@ -38,7 +40,7 @@ def DrawText(canvas, font, x, y, color, text):
                 except Exception:
                     pass
 
-    return len(text_map[0])
+    return charwidth * len(text_orig)
 
 def DrawLine(canvas, x1, y1, x2, y2, color):
     int_points = __coerce_int(x1, y1, x2, y2)

--- a/RGBMatrixEmulator/graphics/__init__.py
+++ b/RGBMatrixEmulator/graphics/__init__.py
@@ -23,22 +23,23 @@ def DrawText(canvas, font, x, y, color, text):
     if (charwidth * len(text) + x) > canvas.width:
         text = text[: (canvas.width + 1 // charwidth) + 1]
 
-    # Ensure text doesn't get drawn as multiple lines
-    linelimit = len(text) * (font.bdf_font.headers['fbbx'] + 1)
+    if len(text) != 0:
+        # Ensure text doesn't get drawn as multiple lines
+        linelimit = len(text) * (font.bdf_font.headers['fbbx'] + 1)
 
-    text_map = font.bdf_font.draw(text, linelimit).todata(2)
-    font_y_offset = -(font.bdf_font.headers['fbby'] + font.bdf_font.headers['fbbyoff'])
+        text_map = font.bdf_font.draw(text, linelimit).todata(2)
+        font_y_offset = -(font.bdf_font.headers['fbby'] + font.bdf_font.headers['fbbyoff'])
 
-    for y2, row in enumerate(text_map):
-        for x2, value in enumerate(row):
-            if value == 1:
-                try:
-                    if isinstance(color, tuple):
-                        canvas.SetPixel(x + x2, y + y2 + font_y_offset, *color)
-                    else:
-                        canvas.SetPixel(x + x2, y + y2 + font_y_offset, color.r, color.g, color.b)
-                except Exception:
-                    pass
+        for y2, row in enumerate(text_map):
+            for x2, value in enumerate(row):
+                if value == 1:
+                    try:
+                        if isinstance(color, tuple):
+                            canvas.SetPixel(x + x2, y + y2 + font_y_offset, *color)
+                        else:
+                            canvas.SetPixel(x + x2, y + y2 + font_y_offset, color.r, color.g, color.b)
+                    except Exception:
+                        pass
 
     return charwidth * len(text_orig)
 


### PR DESCRIPTION
As noted in the file,   mlb-led-scoreboard offday renderer ends up crawling to a halt with this library. The easiest solution I could think of was simply to crop text which is not visible when DrawText is called.