### PR TITLE
Optional r, g, b parameters

### DIFF
--- a/RGBMatrixEmulator/graphics/color.py
+++ b/RGBMatrixEmulator/graphics/color.py
@@ -1,5 +1,5 @@
 class Color:
-    def __init__(self, r, g, b):
+    def __init__(self, r = 0, g = 0, b = 0):
         self.red   = r
         self.green = g
         self.blue  = b


### PR DESCRIPTION
Allows usage of graphics.Color() without parameters like in rpi-rgb-led-matrix