### PR TITLE
Release 0.6.1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include RGBMatrixEmulator/icon.ico
 include RGBMatrixEmulator/icon.png
 include RGBMatrixEmulator/adapters/browser_adapter/static/index.html
 include RGBMatrixEmulator/adapters/browser_adapter/static/assets/client.js

--- a/RGBMatrixEmulator/adapters/browser_adapter/server.py
+++ b/RGBMatrixEmulator/adapters/browser_adapter/server.py
@@ -33,7 +33,7 @@ class Server:
         print("Starting server...")
         
         self.__io_loop = tornado.ioloop.IOLoop.current()
-        thread = threading.Thread(target=self.__io_loop.start, daemon=True)
+        thread = threading.Thread(target=self.__io_loop.start, name="RGBMEServerThread", daemon=True)
         self.__initialize_interrupts()
         thread.start()
 

--- a/RGBMatrixEmulator/adapters/browser_adapter/server.py
+++ b/RGBMatrixEmulator/adapters/browser_adapter/server.py
@@ -33,7 +33,7 @@ class Server:
         print("Starting server...")
         
         self.__io_loop = tornado.ioloop.IOLoop.current()
-        thread = threading.Thread(target=self.__io_loop.start)
+        thread = threading.Thread(target=self.__io_loop.start, daemon=True)
         self.__initialize_interrupts()
         thread.start()
 

--- a/RGBMatrixEmulator/adapters/browser_adapter/static/index.html
+++ b/RGBMatrixEmulator/adapters/browser_adapter/static/index.html
@@ -77,7 +77,7 @@
                               Pixel Style:
                            </td>
                            <td>
-                              {{ options.pixel_size }}
+                              {{ options.pixel_style }}
                            </td>
                         </tr>
                         <tr>

--- a/RGBMatrixEmulator/version.py
+++ b/RGBMatrixEmulator/version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 
 # package version
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 """Installed version of RGBMatrixEmulator."""

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     data_files=[
         ('docs', ['README.md', 'LICENSE', 'description.md']),
         ('RGBMatrixEmulator', [
+            'RGBMatrixEmulator/icon.ico',
             'RGBMatrixEmulator/icon.png',
             'RGBMatrixEmulator/adapters/browser_adapter/static/index.html',
             'RGBMatrixEmulator/adapters/browser_adapter/static/assets/client.js',
@@ -58,7 +59,7 @@ setup(
     ],
     install_requires=[
         'bdfparser<=2.2.0',
-        'pygame<=2.0.1',
+        'pygame>=2.0.1,<3',
         'scikit-image<=0.18.1',
         'tornado>=6.1'
     ],


### PR DESCRIPTION
* Include `icon.ico` in package
  * Closes #29
* Change `pygame` version pin to anything over 2.0 instead of under
  * Closes #30
* Add a thread name to browser adapter for debugging
* Fixes the pixel style in debug text for browser adapter