### PR TITLE
Free images based on url, not blob

### DIFF
--- a/RGBMatrixEmulator/adapters/browser_adapter/static/assets/client.js
+++ b/RGBMatrixEmulator/adapters/browser_adapter/static/assets/client.js
@@ -17,7 +17,6 @@ function init() {
 
     let retryCount = 0;
     let socket = generateSocket();
-    let blobs = [];
 
     function requestImage() { 
         requestStartTime = performance.now();
@@ -80,8 +79,9 @@ function init() {
         ws.onmessage = function(evt) {
             let arrayBuffer = evt.data;
             let blob  = new Blob([new Uint8Array(arrayBuffer)], {type: "image/jpeg"});
+            let old_img = img.src.slice()
             img.src   = window.URL.createObjectURL(blob);
-            window.URL.revokeObjectURL(blob);
+            window.URL.revokeObjectURL(old_img);
     
             let endTime = performance.now();
             let currentTime = endTime - startTime;


### PR DESCRIPTION
I'm not a JS dev by any means, but I believe reading the documentation on [`revokeObjectURL`](https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL), the function needs the string produced by `createObjectURL`, not the blob used to create it. 

A very short test with an eye on Task Manager suggests this keeps the memory Firefox needs for the page to under 400mb, whereas before it would quickly grow to 900+ within a minute of startup