### PR TITLE
Add support for multiple canvases across all adapters

### DIFF
--- a/RGBMatrixEmulator/adapters/base.py
+++ b/RGBMatrixEmulator/adapters/base.py
@@ -1,13 +1,25 @@
 from RGBMatrixEmulator import version
 
+
 class BaseAdapter:
 
     SUPPORTS_ALTERNATE_PIXEL_STYLE = False
+    INSTANCE = None
 
     def __init__(self, width, height, options):
         self.width   = width
         self.height  = height
         self.options = options
+
+        self.loaded  = False
+
+    @classmethod
+    def get_instance(cls, *args, **kwargs):
+        if cls.INSTANCE is None:
+            instance = cls(*args, **kwargs)
+            cls.INSTANCE = instance
+        
+        return cls.INSTANCE
 
     def adjust_pixel_brightness(self, pixel, to_int = False):
         alpha = self.options.brightness / 100.0

--- a/RGBMatrixEmulator/adapters/browser_adapter/adapter.py
+++ b/RGBMatrixEmulator/adapters/browser_adapter/adapter.py
@@ -17,12 +17,17 @@ class BrowserAdapter(BaseAdapter):
         self.image = None
 
     def load_emulator_window(self):
+        if self.loaded:
+            return
+
         print(self.emulator_details_text())
         websocket = ImageWebSocket
         websocket.register_adapter(self)
 
         self.__server = Server(websocket, self.options)
         self.__server.run()
+
+        self.loaded = True
 
     def draw_to_screen(self, pixels):
         image = Image.new("RGB", self.options.window_size())

--- a/RGBMatrixEmulator/adapters/pygame_adapter.py
+++ b/RGBMatrixEmulator/adapters/pygame_adapter.py
@@ -22,12 +22,17 @@ class PygameAdapter(BaseAdapter):
         self.__surface = None
 
     def load_emulator_window(self):
+        if self.loaded:
+            return
+
         print('EMULATOR: Loading {}'.format(self.emulator_details_text()))
         self.__surface = pygame.display.set_mode(self.options.window_size())
         pygame.init()
 
         self.__set_emulator_icon()
         pygame.display.set_caption(self.emulator_details_text())
+
+        self.loaded = True
 
     def draw_to_screen(self, pixels):
         for row, pixel_row in enumerate(pixels):

--- a/RGBMatrixEmulator/adapters/tkinter_adapter.py
+++ b/RGBMatrixEmulator/adapters/tkinter_adapter.py
@@ -15,6 +15,9 @@ class TkinterAdapter(BaseAdapter):
         self.__pixels = None
 
     def load_emulator_window(self):
+        if self.loaded:
+            return
+
         print('EMULATOR: Loading {}'.format(self.emulator_details_text()))
         self.__root = tkinter.Tk()
         self.__set_emulator_icon()
@@ -31,6 +34,8 @@ class TkinterAdapter(BaseAdapter):
 
         self.__initialize_bitmap()
         self.__root.update()
+
+        self.loaded = True
 
     def draw_to_screen(self, pixels):
         for row, pixel_row in enumerate(pixels):

--- a/RGBMatrixEmulator/adapters/turtle_adapter.py
+++ b/RGBMatrixEmulator/adapters/turtle_adapter.py
@@ -26,6 +26,9 @@ class TurtleAdapter(BaseAdapter):
         self.__screen.update()
 
     def load_emulator_window(self):
+        if self.loaded:
+            return
+
         print('EMULATOR: Loading {}'.format(self.emulator_details_text()))
         turtle.setup(*self.options.window_size())
         turtle.title(self.emulator_details_text())
@@ -35,6 +38,8 @@ class TurtleAdapter(BaseAdapter):
         self.__screen.bgcolor(Color.BLACK().to_tuple())
         turtle.tracer(0, 0)
         turtle.colormode(255)
+
+        self.loaded = True
 
     def __draw_pixel(self, pixel):
         self.__pen.color(*pixel.to_tuple())

--- a/RGBMatrixEmulator/emulators/canvas.py
+++ b/RGBMatrixEmulator/emulators/canvas.py
@@ -7,7 +7,7 @@ class Canvas:
 
         self.width = options.cols * options.chain_length
         self.height = options.rows * options.parallel
-        self.display_adapter = options.display_adapter(self.width, self.height, options)
+        self.display_adapter = options.display_adapter.get_instance(self.width, self.height, options)
 
         self.__pixels = [[Color.BLACK() for x in range(0, self.width)] for y in range(0, self.height)]
 

--- a/RGBMatrixEmulator/emulators/matrix.py
+++ b/RGBMatrixEmulator/emulators/matrix.py
@@ -12,16 +12,16 @@ class RGBMatrix:
         self.canvas = None
 
     def CreateFrameCanvas(self):
-        if self.canvas:
-            return self.canvas
+        self.canvas = Canvas(options = self.options)
 
-        return Canvas(options = self.options)
+        return self.canvas
     
     def SwapOnVSync(self, canvas):
         canvas.check_for_quit_event()
         canvas.draw_to_screen()
+        self.canvas = canvas
 
-        return canvas
+        return self.canvas
 
     def Clear(self):
         self.__sync_canvas()

--- a/samples/singleton.py
+++ b/samples/singleton.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# Example of flipping between multiple canvases.
+# Could be useful for double buffering purposes.
+from samplebase import SampleBase
+from RGBMatrixEmulator import graphics
+
+
+class MultCanvas(SampleBase):
+    def __init__(self, *args, **kwargs):
+        super(MultCanvas, self).__init__(*args, **kwargs)
+
+    def run(self):
+        canvas1 = self.matrix.CreateFrameCanvas()
+        canvas2 = self.matrix.CreateFrameCanvas()
+
+        font = graphics.Font()
+        font.LoadFont("./fonts/7x13.bdf")
+        textColor = graphics.Color(255, 255, 0)
+
+        i = 0
+        j = 0
+        while True:
+
+            for num, canvas in enumerate([canvas1, canvas2]):
+
+                i = 0
+
+                while i < 50:
+                    canvas.Clear()
+                    graphics.DrawText(canvas, font, 10, 10, textColor, str(num))
+                    self.matrix.SwapOnVSync(canvas)
+
+                    i += 1
+
+
+# Main function
+if __name__ == "__main__":
+    mc = MultCanvas()
+    if (not mc.process()):
+        mc.print_help()


### PR DESCRIPTION
Moved each adapter to a singleton pattern. Unfortunately wasn't able to come up with a clean solution to fix multiple emu window load messages, but I think this works best since some (but not all) adapter load code may be idempotent.

For the browser adapter, this also needs to be a singleton so that no more than one server can run at a given time. Failing to bind to the configured port because an instance is already running previously blew up with an ugly error.

Includes a sample of multiple canvases

Closes #39 