### PR TITLE
Remove scikit image

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can also change the `pixel_style` option. By default, the emulator represent
 
 ### Display Adapters
 
-By default, `RGBMatrixEmulator` uses `browser` as its display adapter for maximum compatibility with different operating systems as well as thread-safety. However, you can also use other display adapters as well if `pygame` does not suit your needs.
+By default, `RGBMatrixEmulator` uses `browser` as its display adapter for maximum compatibility with different operating systems as well as thread-safety. However, you can also use other display adapters as well if the default adapter does not suit your needs.
 
 Currently supported display adapters are:
 

--- a/RGBMatrixEmulator/graphics/__init__.py
+++ b/RGBMatrixEmulator/graphics/__init__.py
@@ -1,6 +1,3 @@
-from skimage.draw import line as sk_line
-from skimage.draw import circle_perimeter as sk_circle_perimeter
-
 from RGBMatrixEmulator.graphics.color import Color
 from RGBMatrixEmulator.graphics.font import Font
 
@@ -51,17 +48,93 @@ def DrawText(canvas, font, x, y, color, text):
 
 def DrawLine(canvas, x1, y1, x2, y2, color):
     int_points = __coerce_int(x1, y1, x2, y2)
-    rows, cols = sk_line(*int_points)
+    rows, cols = __line(*int_points)
 
     for point in zip(rows, cols):
         canvas.SetPixel(*point, color.red, color.green, color.blue)
 
 def DrawCircle(canvas, x, y, r, color):
     int_points = __coerce_int(x, y)
-    rows, cols = sk_circle_perimeter(*int_points, r)
+    rows, cols = __circle_perimeter(*int_points, r)
 
     for point in zip(rows, cols):
         canvas.SetPixel(*point, color.red, color.green, color.blue)
 
 def __coerce_int(*values):
     return [int(value) for value in values]
+
+def __line(x1, y1, x2, y2):
+    '''
+    Line drawing algorithm
+
+    Extracted from scikit-image:
+    https://github.com/scikit-image/scikit-image/blob/00177e14097237ef20ed3141ed454bc81b308f82/skimage/draw/_draw.pyx#L44
+    '''
+    steep = 0
+    r = x1
+    c = y1
+    dr = abs(x2 - x1)
+    dc = abs(y2 - y1)
+
+    rr = [0] * (max(dc, dr) + 1)
+    cc = [0] * (max(dc, dr) + 1)
+
+    if (y2 - c) > 0:
+        sc = 1
+    else:
+        sc = -1
+    if (x2 - r) > 0:
+        sr = 1
+    else:
+        sr = -1
+    if dr > dc:
+        steep = 1
+        c, r = r, c
+        dc, dr = dr, dc
+        sc, sr = sr, sc
+    d = (2 * dr) - dc
+
+    for i in range(dc):
+        if steep:
+            rr[i] = c
+            cc[i] = r
+        else:
+            rr[i] = r
+            cc[i] = c
+        while d >= 0:
+            r = r + sr
+            d = d - (2 * dc)
+        c = c + sc
+        d = d + (2 * dr)
+
+    rr[dc] = x2
+    cc[dc] = y2
+
+    return (rr, cc)
+
+def __circle_perimeter(x, y, radius):
+    '''
+    Bresenham circle algorithm
+    
+    Extracted from scikit-image
+    https://github.com/scikit-image/scikit-image/blob/00177e14097237ef20ed3141ed454bc81b308f82/skimage/draw/_draw.pyx#L248
+    '''
+    rr = list()
+    cc = list()
+
+    c = 0
+    r = radius
+    d = 3 - 2 * radius
+
+    while r >= c:
+        rr.extend([_ + x for _ in [r, -r, r, -r, c, -c, c, -c]])
+        cc.extend([_ + y for _ in [c, c, -c, -c, r, r, -r, -r]])
+
+        if d < 0:
+            d += 4 * c + 6
+        else:
+            d += 4 * (c - r) + 10
+            r -= 1
+        c += 1
+
+    return (rr, cc)

--- a/RGBMatrixEmulator/version.py
+++ b/RGBMatrixEmulator/version.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
 # package version
-__version__ = '0.7.1'
+__version__ = '0.8.0'
 """Installed version of RGBMatrixEmulator."""
+
+version = __version__
+"""Backwards compatibility for v0.7.x and earlier"""

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
     install_requires=[
         'bdfparser<=2.2.0',
         'pygame>=2.0.1,<3',
-        'scikit-image>=0.19.2',
         'tornado>=6.1'
     ],
     include_package_data=True


### PR DESCRIPTION
Removes a huge dependency chain for scikit-image that is only used for circle and line drawing algorithms. Extracted algorithms from scikit-image.