### PR TITLE
Release v0.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The first time you run a script with the emulator enabled, a file called `emulat
   "pixel_style": "square",
   "display_adapter": "pygame",
   "suppress_font_warnings": false,
+  "suppress_adapter_load_errors": false,
   "browser": {
     "_comment": "For use with the browser adapter only.",
     "port": 8888,
@@ -55,7 +56,8 @@ The first time you run a script with the emulator enabled, a file called `emulat
     "quality": 70,
     "image_border": true,
     "debug_text": false
-  }
+  },
+  "log_level": "info"
 }
 ```
 
@@ -92,7 +94,7 @@ Currently supported display adapters are:
 
 You can swap display adapters by changing the `display_adapter` value to one of the above in `emulator_config.json`.
 
-**Note:** Not all display adapters support all emulator features.
+**Note:** Not all display adapters support all emulator features. Some adapters may require additional setup steps to install. For example, on OSX, it may be necessary to install `tkinter` via Homebrew (`brew install python-tk`).
 
 ### Browser Display Adapter
 

--- a/RGBMatrixEmulator/adapters/__init__.py
+++ b/RGBMatrixEmulator/adapters/__init__.py
@@ -1,13 +1,63 @@
-from RGBMatrixEmulator.adapters.browser_adapter.adapter import BrowserAdapter
-from RGBMatrixEmulator.adapters.pygame_adapter import PygameAdapter
-from RGBMatrixEmulator.adapters.terminal_adapter import TerminalAdapter
-from RGBMatrixEmulator.adapters.tkinter_adapter import TkinterAdapter
-from RGBMatrixEmulator.adapters.turtle_adapter import TurtleAdapter
+import importlib, json
 
-ADAPTER_TYPES = {
-    'browser':  BrowserAdapter,
-    'pygame':   PygameAdapter,
-    'terminal': TerminalAdapter,
-    'tkinter':  TkinterAdapter,
-    'turtle':   TurtleAdapter
-}
+from RGBMatrixEmulator.logger import Logger
+
+adapters = [
+    {
+        'path': 'RGBMatrixEmulator.adapters.browser_adapter.adapter', 
+        'class': 'BrowserAdapter', 
+        'type': 'browser'
+    },
+    {
+        'path': 'RGBMatrixEmulator.adapters.pygame_adapter',          
+        'class': 'PygameAdapter',  
+        'type': 'pygame'
+    },
+    {
+        'path': 'RGBMatrixEmulator.adapters.terminal_adapter',        
+        'class': 'TerminalAdapter',
+        'type': 'terminal'
+    },
+    {
+        'path': 'RGBMatrixEmulator.adapters.tkinter_adapter',         
+        'class': 'TkinterAdapter', 
+        'type': 'tkinter'
+    },
+    {
+        'path': 'RGBMatrixEmulator.adapters.turtle_adapter',          
+        'class': 'TurtleAdapter',  
+        'type': 'turtle'
+    }
+]
+
+ADAPTER_TYPES = {}
+
+try:
+    with open("emulator_config.json") as config_file:
+        suppress_adapter_load_errors = json.load(config_file).get("suppress_adapter_load_errors", False)
+except:
+    suppress_adapter_load_errors = False
+
+for adapter in adapters:
+    package_path = adapter.get('path')
+    adapter_class = adapter.get('class')
+    adapter_name = adapter.get('type')
+    try:
+        package = importlib.import_module(package_path)
+        adapter = getattr(package, adapter_class)
+
+        ADAPTER_TYPES[adapter_name] = adapter
+    except Exception as ex:
+        if suppress_adapter_load_errors: continue
+
+        Logger.exception(f'''
+Failed to load {adapter_class} for "{adapter_name}" display adapter!
+
+If this is not your configured display adapter, the emulator will continue to load.
+
+You can suppress this error in the `emulator_config.json` by adding:
+
+  "suppress_adapter_load_errors": true
+
+'''
+        )

--- a/RGBMatrixEmulator/adapters/browser_adapter/adapter.py
+++ b/RGBMatrixEmulator/adapters/browser_adapter/adapter.py
@@ -5,6 +5,7 @@ from PIL import Image, ImageDraw
 from RGBMatrixEmulator.adapters.base import BaseAdapter
 from RGBMatrixEmulator.adapters.browser_adapter.server import Server
 from RGBMatrixEmulator.adapters.browser_adapter.web_socket import ImageWebSocket
+from RGBMatrixEmulator.logger import Logger
 
 
 class BrowserAdapter(BaseAdapter):
@@ -20,7 +21,7 @@ class BrowserAdapter(BaseAdapter):
         if self.loaded:
             return
 
-        print(self.emulator_details_text())
+        Logger.info(self.emulator_details_text())
         websocket = ImageWebSocket
         websocket.register_adapter(self)
 

--- a/RGBMatrixEmulator/adapters/browser_adapter/server.py
+++ b/RGBMatrixEmulator/adapters/browser_adapter/server.py
@@ -8,6 +8,8 @@ import tornado.ioloop
 from os import path
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 
+from RGBMatrixEmulator.logger import Logger
+
 
 asyncio.set_event_loop_policy(AnyThreadEventLoopPolicy())
 
@@ -42,7 +44,7 @@ class Server:
 
     def run(self):     
         if not self.instance.listening:
-            print("Starting server...")
+            Logger.info("Starting server...")
 
             self.instance.listening = True
             self.instance.app.listen(self.instance.options.browser.port)
@@ -51,7 +53,7 @@ class Server:
             self.__initialize_interrupts()
             thread.start()
 
-            print("Server started and ready to accept requests on http://localhost:" + str(self.instance.options.browser.port) + "/")
+            Logger.info("Server started and ready to accept requests on http://localhost:" + str(self.instance.options.browser.port) + "/")
 
     def __initialize_interrupts(self):
         '''

--- a/RGBMatrixEmulator/adapters/browser_adapter/web_socket.py
+++ b/RGBMatrixEmulator/adapters/browser_adapter/web_socket.py
@@ -1,5 +1,8 @@
 import tornado.websocket
 
+from RGBMatrixEmulator.logger import Logger
+
+
 class ImageWebSocket(tornado.websocket.WebSocketHandler):
     clients = set()
     adapter = None
@@ -10,11 +13,11 @@ class ImageWebSocket(tornado.websocket.WebSocketHandler):
 
     def open(self):
         ImageWebSocket.clients.add(self)
-        print("WebSocket opened from: " + self.request.remote_ip)
+        Logger.info("WebSocket opened from: " + self.request.remote_ip)
 
     def on_message(self, _message):
         if not ImageWebSocket.adapter.image:
-            print("EMULATOR WARNING: No image received from {}!".format(ImageWebSocket.adapter.__class__.__name__))
+            Logger.warning("No image received from {}!".format(ImageWebSocket.adapter.__class__.__name__))
             return
 
         jpeg_bytes = ImageWebSocket.adapter.image

--- a/RGBMatrixEmulator/adapters/pygame_adapter.py
+++ b/RGBMatrixEmulator/adapters/pygame_adapter.py
@@ -11,6 +11,7 @@ import pygame
 
 from pygame.locals import QUIT
 from RGBMatrixEmulator.adapters.base import BaseAdapter
+from RGBMatrixEmulator.logger import Logger
 
 
 class PygameAdapter(BaseAdapter):
@@ -25,7 +26,7 @@ class PygameAdapter(BaseAdapter):
         if self.loaded:
             return
 
-        print('EMULATOR: Loading {}'.format(self.emulator_details_text()))
+        Logger.info('Loading {}'.format(self.emulator_details_text()))
         self.__surface = pygame.display.set_mode(self.options.window_size())
         pygame.init()
 

--- a/RGBMatrixEmulator/adapters/tkinter_adapter.py
+++ b/RGBMatrixEmulator/adapters/tkinter_adapter.py
@@ -2,6 +2,7 @@ import tkinter
 import os
 
 from RGBMatrixEmulator.adapters.base import BaseAdapter
+from RGBMatrixEmulator.logger import Logger
 
 
 class TkinterAdapter(BaseAdapter):
@@ -18,7 +19,7 @@ class TkinterAdapter(BaseAdapter):
         if self.loaded:
             return
 
-        print('EMULATOR: Loading {}'.format(self.emulator_details_text()))
+        Logger.info('Loading {}'.format(self.emulator_details_text()))
         self.__root = tkinter.Tk()
         self.__set_emulator_icon()
         self.__root.title(self.emulator_details_text())

--- a/RGBMatrixEmulator/adapters/turtle_adapter.py
+++ b/RGBMatrixEmulator/adapters/turtle_adapter.py
@@ -4,6 +4,7 @@ import turtle
 
 from RGBMatrixEmulator.adapters.base import BaseAdapter
 from RGBMatrixEmulator.graphics.color import Color
+from RGBMatrixEmulator.logger import Logger
 
 
 class TurtleAdapter(BaseAdapter):
@@ -29,7 +30,7 @@ class TurtleAdapter(BaseAdapter):
         if self.loaded:
             return
 
-        print('EMULATOR: Loading {}'.format(self.emulator_details_text()))
+        Logger.info('Loading {}'.format(self.emulator_details_text()))
         turtle.setup(*self.options.window_size())
         turtle.title(self.emulator_details_text())
         self.__pen = turtle.Turtle(visible = False)

--- a/RGBMatrixEmulator/emulators/options.py
+++ b/RGBMatrixEmulator/emulators/options.py
@@ -1,6 +1,4 @@
-import json
-import os
-import pprint
+import json, os, pprint, sys
 
 from RGBMatrixEmulator.adapters import ADAPTER_TYPES
 from RGBMatrixEmulator.logger import Logger
@@ -27,9 +25,15 @@ class RGBMatrixOptions:
 
         if emulator_config.display_adapter.lower() in ADAPTER_TYPES:
             self.display_adapter = ADAPTER_TYPES[emulator_config.display_adapter.lower()]
-        else:
+        elif len(ADAPTER_TYPES.keys()) > 0:
             adapter_types = ', '.join('"{}"'.format(key) for key in ADAPTER_TYPES.keys())
-            default_adapter = emulator_config.DEFAULT_CONFIG.get('display_adapter')
+
+            # Try to set it to the emulator default, but if it failed to load, pick the first one that did.
+            if emulator_config.DEFAULT_CONFIG.get('display_adapter') in ADAPTER_TYPES:
+                default_adapter = emulator_config.DEFAULT_CONFIG.get('display_adapter')
+            else:
+                default_adapter = list(ADAPTER_TYPES.keys())[0]
+
             Logger.warning('"{}" display adapter option not recognized. Valid adapters are {}. Defaulting to "{}"...'.format(
                     emulator_config.display_adapter,
                     adapter_types,
@@ -37,6 +41,10 @@ class RGBMatrixOptions:
                 )
             )
             self.display_adapter = ADAPTER_TYPES[default_adapter]
+        else:
+            Logger.critical("Failed to find a valid display adapter to load! Check that you have installed dependencies required for your configured adapter.")
+
+            sys.exit(1)
 
         self.pixel_style = emulator_config.DEFAULT_CONFIG.get('pixel_style')
         config_pixel_style = emulator_config.pixel_style.lower()

--- a/RGBMatrixEmulator/emulators/options.py
+++ b/RGBMatrixEmulator/emulators/options.py
@@ -3,6 +3,7 @@ import os
 import pprint
 
 from RGBMatrixEmulator.adapters import ADAPTER_TYPES
+from RGBMatrixEmulator.logger import Logger
 
 
 class RGBMatrixOptions:
@@ -28,8 +29,14 @@ class RGBMatrixOptions:
             self.display_adapter = ADAPTER_TYPES[emulator_config.display_adapter.lower()]
         else:
             adapter_types = ', '.join('"{}"'.format(key) for key in ADAPTER_TYPES.keys())
-            print('EMULATOR: Warning! "{}" display adapter option not recognized. Valid adapters are {}. Defaulting to "pygame"...'.format(emulator_config.display_adapter, adapter_types))
-            self.display_adapter = ADAPTER_TYPES[emulator_config.DEFAULT_CONFIG.get('display_adapter')]
+            default_adapter = emulator_config.DEFAULT_CONFIG.get('display_adapter')
+            Logger.warning('"{}" display adapter option not recognized. Valid adapters are {}. Defaulting to "{}"...'.format(
+                    emulator_config.display_adapter,
+                    adapter_types,
+                    default_adapter
+                )
+            )
+            self.display_adapter = ADAPTER_TYPES[default_adapter]
 
         self.pixel_style = emulator_config.DEFAULT_CONFIG.get('pixel_style')
         config_pixel_style = emulator_config.pixel_style.lower()
@@ -39,9 +46,9 @@ class RGBMatrixOptions:
                 if self.display_adapter.SUPPORTS_ALTERNATE_PIXEL_STYLE:
                     self.pixel_style = emulator_config.pixel_style
                 else:
-                    print('EMULATOR: Warning! "{}" pixel style option is not supported by adapter "{}". Defaulting to "square"...'.format(config_pixel_style, emulator_config.display_adapter.lower()))
+                    Logger.warning('"{}" pixel style option is not supported by adapter "{}". Defaulting to "square"...'.format(config_pixel_style, emulator_config.display_adapter.lower()))
         else:
-            print('EMULATOR: Warning! "{}" pixel style option not recognized. Valid options are "square", "circle". Defaulting to "square"...'.format(config_pixel_style))
+            Logger.warning('"{}" pixel style option not recognized. Valid options are "square", "circle". Defaulting to "square"...'.format(config_pixel_style))
 
         self.pixel_size = emulator_config.pixel_size
         self.browser = emulator_config.browser
@@ -69,6 +76,7 @@ class RGBMatrixEmulatorConfig:
         'pixel_style': 'square',
         'display_adapter': 'browser',
         'suppress_font_warnings': False,
+        'suppress_adapter_load_errors': False,
         'browser': {
             '_comment': 'For use with the browser adapter only.',
             'port': 8888,
@@ -77,7 +85,8 @@ class RGBMatrixEmulatorConfig:
             'quality': 70,
             'image_border': True,
             'debug_text': False
-        }
+        },
+        "log_level": "info"
     }
 
     def __init__(self):

--- a/RGBMatrixEmulator/logger.py
+++ b/RGBMatrixEmulator/logger.py
@@ -1,0 +1,29 @@
+import json, logging
+
+# Try to load the config from file. (Default: INFO)
+try:
+    with open("emulator_config.json") as config_file:
+        log_level_name = json.load(config_file).get("log_level", 'INFO').upper()
+        log_level = getattr(logging, log_level_name)
+except:
+    log_level = logging.INFO
+
+# Create a Logger
+Logger = logging.getLogger('RGBME')
+Logger.setLevel(log_level)
+
+# Create console handler and set the log level
+ch = logging.StreamHandler()
+ch.setLevel(log_level)
+
+# Create formatter
+formatter = logging.Formatter(
+    '[%(asctime)s] [%(name)s] [%(levelname)s]: %(message)s',
+    datefmt = '%Y-%m-%d %H:%M:%S'
+)
+
+# Add formatter to console handler
+ch.setFormatter(formatter)
+
+# Add console handler to Logger
+Logger.addHandler(ch)

--- a/RGBMatrixEmulator/version.py
+++ b/RGBMatrixEmulator/version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 
 # package version
-__version__ = '0.8.1'
+__version__ = '0.8.2'
 """Installed version of RGBMatrixEmulator."""


### PR DESCRIPTION
* Adds a logger instead of `print` statements with customizable log level
* Changes adapter loading to be dynamic and gracefully continue running (if it can)