### PR TITLE
Implement a sixel renderer

### DIFF
--- a/RGBMatrixEmulator/adapters/__init__.py
+++ b/RGBMatrixEmulator/adapters/__init__.py
@@ -4,28 +4,33 @@ from RGBMatrixEmulator.logger import Logger
 
 adapters = [
     {
-        'path': 'RGBMatrixEmulator.adapters.browser_adapter.adapter', 
-        'class': 'BrowserAdapter', 
+        'path': 'RGBMatrixEmulator.adapters.browser_adapter.adapter',
+        'class': 'BrowserAdapter',
         'type': 'browser'
     },
     {
-        'path': 'RGBMatrixEmulator.adapters.pygame_adapter',          
-        'class': 'PygameAdapter',  
+        'path': 'RGBMatrixEmulator.adapters.pygame_adapter',
+        'class': 'PygameAdapter',
         'type': 'pygame'
     },
     {
-        'path': 'RGBMatrixEmulator.adapters.terminal_adapter',        
+        'path': 'RGBMatrixEmulator.adapters.sixel_adapter',
+        'class': 'SixelAdapter',
+        'type': 'sixel'
+    },
+    {
+        'path': 'RGBMatrixEmulator.adapters.terminal_adapter',
         'class': 'TerminalAdapter',
         'type': 'terminal'
     },
     {
-        'path': 'RGBMatrixEmulator.adapters.tkinter_adapter',         
-        'class': 'TkinterAdapter', 
+        'path': 'RGBMatrixEmulator.adapters.tkinter_adapter',
+        'class': 'TkinterAdapter',
         'type': 'tkinter'
     },
     {
-        'path': 'RGBMatrixEmulator.adapters.turtle_adapter',          
-        'class': 'TurtleAdapter',  
+        'path': 'RGBMatrixEmulator.adapters.turtle_adapter',
+        'class': 'TurtleAdapter',
         'type': 'turtle'
     }
 ]

--- a/RGBMatrixEmulator/adapters/sixel_adapter.py
+++ b/RGBMatrixEmulator/adapters/sixel_adapter.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import io
+import libsixel as sixel
+
+from PIL import Image, ImageDraw, ImageEnhance
+from typing import List
+
+from RGBMatrixEmulator.adapters.base import BaseAdapter
+from RGBMatrixEmulator.graphics.color import Color
+
+
+def enlarge_pixels(pixels: List[List[Color]], scale: int, outline: int) -> Image.Image:
+    outline_color = '#000000'
+    w, h = len(pixels[0]), len(pixels)
+    iw, ih = w * scale, h * scale
+    i = Image.new('RGBA', (iw, ih))
+    d = ImageDraw.Draw(i)
+
+    for y, row in enumerate(pixels):
+        for x, color in enumerate(row):
+            rx, ry = x * scale, y * scale
+            ex, ey = rx + (scale - 1), ry + (scale - 1)
+            # todo: support circles
+            d.rectangle([(rx, ry), (ex, ey)], fill=color.to_tuple(), outline=outline_color, width=outline)
+
+    brightness = ImageEnhance.Brightness(i)
+    i = brightness.enhance(1.5)
+    contrast = ImageEnhance.Contrast(i)
+    i = contrast.enhance(0.8)
+
+    return i
+
+
+def encode_sixels(pixels: List[List[Color]], scale=4, outline=1) -> str:
+    '''Encodes given Image to a sixel string.'''
+    img = enlarge_pixels(pixels, scale, outline)
+    img_data = img.convert('RGB').tobytes()
+    width = img.width
+    height = img.height
+    with io.BytesIO() as buf:
+        output = sixel.sixel_output_new(lambda data, buffer: buffer.write(data), buf)
+        dither = sixel.sixel_dither_new(256)
+        sixel.sixel_dither_initialize(dither, img_data, width, height, sixel.SIXEL_PIXELFORMAT_RGB888)
+        sixel.sixel_encode(img_data, width, height, 1, dither, output)
+
+        encoded = buf.getvalue().decode('ascii')
+
+        sixel.sixel_dither_unref(dither)
+        sixel.sixel_output_unref(output)
+
+    return encoded
+
+class SixelAdapter(BaseAdapter):
+    def __init__(self, width, height, options):
+        super().__init__(width, height, options)
+
+    def draw_to_screen(self, pixels):
+        sixel = encode_sixels(pixels,
+                              scale=self.options.pixel_size,
+                              outline=self.options.pixel_outline)
+        output = f"\033[H\n{sixel}\n"
+        sys.stdout.write(output)
+
+    def load_emulator_window(self):
+        os.system('cls||clear')
+        os.system('mode con: cols={} lines={}'.format(self.width * 2 + 5, self.height + 3))

--- a/RGBMatrixEmulator/adapters/sixel_adapter.py
+++ b/RGBMatrixEmulator/adapters/sixel_adapter.py
@@ -52,9 +52,6 @@ def encode_sixels(pixels: List[List[Color]], scale=4, outline=1) -> str:
     return encoded
 
 class SixelAdapter(BaseAdapter):
-    def __init__(self, width, height, options):
-        super().__init__(width, height, options)
-
     def draw_to_screen(self, pixels):
         sixel = encode_sixels(pixels,
                               scale=self.options.pixel_size,

--- a/RGBMatrixEmulator/emulators/options.py
+++ b/RGBMatrixEmulator/emulators/options.py
@@ -82,7 +82,7 @@ class RGBMatrixEmulatorConfig:
 
     VALID_PIXEL_STYLES = ['square', 'circle']
     DEFAULT_CONFIG = {
-        'pixel_outline': 2,
+        'pixel_outline': 0,
         'pixel_size': 16,
         'pixel_style': 'square',
         'display_adapter': 'browser',

--- a/RGBMatrixEmulator/emulators/options.py
+++ b/RGBMatrixEmulator/emulators/options.py
@@ -59,6 +59,7 @@ class RGBMatrixOptions:
             Logger.warning('"{}" pixel style option not recognized. Valid options are "square", "circle". Defaulting to "square"...'.format(config_pixel_style))
 
         self.pixel_size = emulator_config.pixel_size
+        self.pixel_outline = emulator_config.pixel_outline
         self.browser = emulator_config.browser
 
         if emulator_config.suppress_font_warnings:
@@ -80,6 +81,7 @@ class RGBMatrixEmulatorConfig:
 
     VALID_PIXEL_STYLES = ['square', 'circle']
     DEFAULT_CONFIG = {
+        'pixel_outline': 2,
         'pixel_size': 16,
         'pixel_style': 'square',
         'display_adapter': 'browser',
@@ -108,7 +110,7 @@ class RGBMatrixEmulatorConfig:
             with open(self.__CONFIG_PATH) as f:
                 config = json.load(f)
 
-            return config    
+            return config
 
         with open(self.__CONFIG_PATH, 'w') as f:
             json.dump(self.DEFAULT_CONFIG, f, indent=4)

--- a/RGBMatrixEmulator/emulators/options.py
+++ b/RGBMatrixEmulator/emulators/options.py
@@ -59,6 +59,7 @@ class RGBMatrixOptions:
             Logger.warning('"{}" pixel style option not recognized. Valid options are "square", "circle". Defaulting to "square"...'.format(config_pixel_style))
 
         self.pixel_size = emulator_config.pixel_size
+        self.pixel_outline = emulator_config.DEFAULT_CONFIG.get('pixel_outline')
         self.pixel_outline = emulator_config.pixel_outline
         self.browser = emulator_config.browser
 

--- a/RGBMatrixEmulator/emulators/options.py
+++ b/RGBMatrixEmulator/emulators/options.py
@@ -59,7 +59,7 @@ class RGBMatrixOptions:
             Logger.warning('"{}" pixel style option not recognized. Valid options are "square", "circle". Defaulting to "square"...'.format(config_pixel_style))
 
         self.pixel_size = emulator_config.pixel_size
-        self.pixel_outline = emulator_config.DEFAULT_CONFIG.get('pixel_outline')
+        self.pixel_outline = emulator_config.DEFAULT_CONFIG['pixel_outline']
         self.pixel_outline = emulator_config.pixel_outline
         self.browser = emulator_config.browser
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ setup(
     install_requires=[
         'bdfparser<=2.2.0',
         'pygame>=2.0.1,<3',
-        'tornado>=6.1'
+        'tornado>=6.1',
+        'libsixel-python>=0.5.0',
     ],
     include_package_data=True
 )


### PR DESCRIPTION
As I mentioned in #50, here's an implementation of sixel support.

Note that I added a new option `pixel_outline` to add outline around individual pixels.

<img width="1172" alt="Screenshot 2023-06-09 at 23 41 24" src="https://github.com/ty-porter/RGBMatrixEmulator/assets/5663391/9bf0b3dc-5084-4f3f-8970-75b399aada8a">


On mac use brew to [install libsixel](https://github.com/saitoha/libsixel), and a compatible terminal is required. 