### PR TITLE
Make the websocket connection auto reconnect even on server restart

### DIFF
--- a/RGBMatrixEmulator/adapters/browser_adapter/static/assets/client.js
+++ b/RGBMatrixEmulator/adapters/browser_adapter/static/assets/client.js
@@ -49,7 +49,7 @@ function init() {
             setTimeout(function() {
                 // We generate socket with a timeout to make sure server has time to recover.
                 socket = generateSocket();
-            }, 2000);
+            }, WS_RETRY_DELAY);
         }
 
         ws.onerror = function() {

--- a/RGBMatrixEmulator/adapters/browser_adapter/static/assets/client.js
+++ b/RGBMatrixEmulator/adapters/browser_adapter/static/assets/client.js
@@ -1,7 +1,6 @@
 function init() {
-    const WS_ERROR_TIMEOUT = 6 * 1000;
-    const WS_MAX_RETRY     = 10;
-    const FPS_DEFAULT      = 24;
+    const WS_RETRY_DELAY = 2000;
+    const FPS_DEFAULT    = 24;
 
     let img       = document.getElementById("liveImg");
     let fpsText   = document.getElementById("fps");
@@ -15,38 +14,11 @@ function init() {
     let requestTimeSmoothing = 0.2;    // larger=more smoothing
     let targetTime = 1000 / fpsTarget;
 
-    let retryCount = 0;
     let socket = generateSocket();
 
-    function requestImage() { 
+    function requestImage() {
         requestStartTime = performance.now();
-
-        waitForSocketReady(socket, function () {
-            socket.send('more');
-        });
-    }
-
-    function waitForSocketReady(socket, callback) {
-        if (socketReady(socket)) {
-            retryCount = 0;
-            return callback();
-        }
-        else if (retryCount < WS_MAX_RETRY) {
-            let retriesRemaining = WS_MAX_RETRY - retryCount;
-            let retryText = retriesRemaining == 1 ? "retry" : "retries"
-            console.error(`Failed to fetch next frame. Retrying in ${WS_ERROR_TIMEOUT / 1000}s... (${retriesRemaining} ${retryText} remaining)`);
-            retryCount += 1;
-
-            setTimeout(function () {
-                waitForSocketReady(socket, callback);
-            }, WS_ERROR_TIMEOUT);
-        } else {
-            console.error(`Max retries exhausted. Confirm that the server is still running on ${location.host}.`);
-        }
-    }
-
-    function socketReady(socket) {
-        return socket.readyState == socket.OPEN;
+        socket.send('more');
     }
 
     function generateSocket() {
@@ -55,7 +27,7 @@ function init() {
         if (path.endsWith("index.html")) {
             path = path.substring(0, path.length - "index.html".length);
         }
-        
+
         if(!path.endsWith("/")) {
             path = path + "/";
         }
@@ -64,7 +36,7 @@ function init() {
         let ws = new WebSocket(wsProtocol + location.host + path + "websocket");
 
         ws.binaryType = 'arraybuffer';
-    
+
         ws.onopen = function() {
             console.log("RGBME WebSocket connection established!");
             startTime = performance.now();
@@ -72,17 +44,25 @@ function init() {
         };
 
         ws.onclose = function() {
-            // Handle retries via requestImage call
-            requestImage();
+            // Handle retries by recreating the connection to websocket.
+            console.warn(`RGBME WebSocket connection lost. Retrying in ${WS_RETRY_DELAY / 1000}s.`)
+            setTimeout(function() {
+                // We generate socket with a timeout to make sure server has time to recover.
+                socket = generateSocket();
+            }, 2000);
         }
-    
+
+        ws.onerror = function() {
+            ws.close();
+        }
+
         ws.onmessage = function(evt) {
             let arrayBuffer = evt.data;
             let blob  = new Blob([new Uint8Array(arrayBuffer)], {type: "image/jpeg"});
             let old_img = img.src.slice()
             img.src   = window.URL.createObjectURL(blob);
             window.URL.revokeObjectURL(old_img);
-    
+
             let endTime = performance.now();
             let currentTime = endTime - startTime;
             // smooth with moving average
@@ -93,12 +73,12 @@ function init() {
             if (fpsText) {
                 fpsText.textContent = fps;
             }
-            
+
             let currentRequestTime = performance.now() - requestStartTime;
             // smooth with moving average
             requestTime = (requestTime * requestTimeSmoothing) + (currentRequestTime * (1.0 - requestTimeSmoothing));
             let timeout = Math.max(0, targetTime - requestTime);
-    
+
             setTimeout(requestImage, timeout);
         };
 


### PR DESCRIPTION
Hi! Here's a small patch to make websocket connections a bit more robust.

Before: If I restart my emulator process, I need to refresh the webpage (the retries did not work for me, it never reconnected).

Now: If I restart my emulator, the websocket connection is automatically re-established, and I do not need to refresh. 