### PR TITLE
Fix scaling issue when not using standard 32x32 matrix

### DIFF
--- a/RGBMatrixEmulator/emulation/canvas.py
+++ b/RGBMatrixEmulator/emulation/canvas.py
@@ -10,8 +10,8 @@ class Canvas:
         self.width = options.cols * options.chain_length
         self.height = options.rows * options.parallel
 
-        # 3D numpy array -- w, h, 3-tuple RGB
-        self.__pdims = (self.width, self.height, 3)
+        # 3D numpy array -- rows (H), columns (W), 3-tuple RGB
+        self.__pdims = (self.height, self.width, 3)
 
         self.display_adapter = options.display_adapter.get_instance(
             self.width, self.height, options


### PR DESCRIPTION
Addresses #86

The pixel buffer was converted to a numpy array in #81 

The buffer size was intended to be a 3D array of `rows x columns x 3` (for a 3-tuple RGB) but was mistakenly interchanged to `columns x rows x 3`. This caused an unintentional scaling effect on matrix sizes where the width and height were unequal

Retested using `image-scroller` sample:

```sh
python .\image-scroller.py --led-cols=64
```