### PR TITLE
Refactor real mask gradient for better visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The default configuration is as follows:
   "pixel_outline": 0,
   "pixel_size": 16,
   "pixel_style": "square",
-  "pixel_glow": "auto",
+  "pixel_glow": 6,
   "display_adapter": "browser",
   "suppress_font_warnings": false,
   "suppress_adapter_load_errors": false,

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The default configuration is as follows:
 pixel_outline          (Integer): Size of the black border around each pixel. Only works on some adapters; others will ignore this configuration.
 pixel_size             (Integer): Size of the emulated LED. Helpful for emulating large matrices on small screens. Actual window size is the matrix size scaled by pixel size.
 pixel_style            (String):  Style of the emulated LED. Supported pixel styles are "square", "circle", and "real". Some display adapters do not support all options and will revert to a supported style.
-pixel_glow             (Integer): Amount of glow to add to pixels. Currently only supported by "real" pixel style. Defaults to "auto", otherwise must be an integer >= 0.
+pixel_glow             (Integer): Amount of glow to add to pixels. Currently only supported by "real" pixel style. Must be an integer >= 0.
 display_adapter        (String):  Display adapter for the emulator. See Display Adapters section for details.
 suppress_font_warnings (Boolean): Suppress BDF font parsing errors, such as for missing characters.
 browser                (Dict):    Additional configuration options for the "browser" display adapter. Does nothing for other adapters.

--- a/RGBMatrixEmulator/emulation/options.py
+++ b/RGBMatrixEmulator/emulation/options.py
@@ -83,12 +83,10 @@ Defaulting to "{}"...
             )
 
         self.pixel_glow = emulator_config.pixel_glow
-        if self.pixel_glow != "auto" and not (
-            isinstance(self.pixel_glow, int) and self.pixel_glow >= 0
-        ):
+        if not (isinstance(self.pixel_glow, int) and self.pixel_glow >= 0):
             Logger.warning(
-                '"{}" pixel bleed option not recognized. Valid options are "auto" and integers >= 0. Defaulting to "auto"...'.format(
-                    self.pixel_glow
+                '"{}" pixel bleed option not recognized. Valid options are integers >= 0. Defaulting to {}...'.format(
+                    self.pixel_glow, emulator_config.DEFAULT_CONFIG.get("pixel_glow")
                 )
             )
 

--- a/RGBMatrixEmulator/emulation/options.py
+++ b/RGBMatrixEmulator/emulation/options.py
@@ -121,7 +121,7 @@ class RGBMatrixEmulatorConfig:
         "pixel_outline": 0,
         "pixel_size": 16,
         "pixel_style": "square",
-        "pixel_glow": "auto",
+        "pixel_glow": 6,
         "display_adapter": "browser",
         "suppress_font_warnings": False,
         "suppress_adapter_load_errors": False,


### PR DESCRIPTION
32x32 `samples/rotating-block-generator.py` with default 0.25 glow
![image](https://github.com/user-attachments/assets/d0aad9d9-ac13-4b08-9d12-57080bd060cf)

32x32 mlb-led-scoreboard with default glow
![image](https://github.com/user-attachments/assets/4c4827b2-761e-47ca-b792-7a7db8720ae6)

32x32 mlb-led-scoreboard with 0.5 glow
![image](https://github.com/user-attachments/assets/2619d64f-cdad-42f6-b27e-a9d1b6c6b7b5)
