### PR TITLE
Add white-label icons and emulator titles

### DIFF
--- a/RGBMatrixEmulator/adapters/base.py
+++ b/RGBMatrixEmulator/adapters/base.py
@@ -1,4 +1,5 @@
 import numpy as np
+from pathlib import Path
 
 from PIL import Image, ImageDraw
 from RGBMatrixEmulator import version
@@ -17,6 +18,10 @@ class BaseAdapter:
         PixelStyle.REAL: "_draw_real_mask",
     }
 
+    DEBUG_TEXT_TEMPLATE = (
+        "RGBME v{} - {}x{} Matrix | {}x{} Chain | {}px per LED ({}) | {}"
+    )
+
     def __init__(self, width, height, options):
         self.width = width
         self.height = height
@@ -25,6 +30,11 @@ class BaseAdapter:
         self.__mask = self.__draw_mask()
         self.loaded = False
 
+        self.emulator_title = self.options.emulator_title or str(self)
+
+        self.default_icon_path = (Path(__file__).parent / ".." / "icon.png").resolve()
+        self.icon_path = self.options.icon_path or self.default_icon_path
+
     @classmethod
     def get_instance(cls, *args, **kwargs):
         if cls.INSTANCE is None:
@@ -32,20 +42,6 @@ class BaseAdapter:
             cls.INSTANCE = instance
 
         return cls.INSTANCE
-
-    def emulator_details_text(self):
-        details_text = "RGBME v{} - {}x{} Matrix | {}x{} Chain | {}px per LED ({}) | {}"
-
-        return details_text.format(
-            version.__version__,
-            self.options.cols,
-            self.options.rows,
-            self.options.chain_length,
-            self.options.parallel,
-            self.options.pixel_size,
-            self.options.pixel_style.name,
-            self.__class__.__name__,
-        )
 
     # This method is required for the pygame adapter but nothing else, so just skip it if not defined.
     def check_for_quit_event(self):
@@ -183,3 +179,15 @@ class BaseAdapter:
         which produces fewer graphical artifacts than summation by average of the two points.
         """
         return np.clip((g1 - 128) + (g2 - 128), 0, 255)
+
+    def __str__(self):
+        return self.DEBUG_TEXT_TEMPLATE.format(
+            version.__version__,
+            self.options.cols,
+            self.options.rows,
+            self.options.chain_length,
+            self.options.parallel,
+            self.options.pixel_size,
+            self.options.pixel_style.name,
+            self.__class__.__name__,
+        )

--- a/RGBMatrixEmulator/adapters/browser_adapter/adapter.py
+++ b/RGBMatrixEmulator/adapters/browser_adapter/adapter.py
@@ -1,4 +1,5 @@
 import io
+from pathlib import Path
 
 from RGBMatrixEmulator.adapters.base import BaseAdapter
 from RGBMatrixEmulator.adapters import PixelStyle
@@ -33,11 +34,17 @@ class BrowserAdapter(BaseAdapter):
                 self.default_image_format.lower()
             )
 
+        # Default icon path is browser adapter assets
+        self.default_icon_path = str(
+            (Path(__file__).parent / "static" / "assets" / "icon.ico").resolve()
+        )
+        self.icon_path = self.options.icon_path or self.default_icon_path
+
     def load_emulator_window(self):
         if self.loaded:
             return
 
-        Logger.info(self.emulator_details_text())
+        Logger.info(self.emulator_title)
 
         self.__server = Server(self)
         self.__server.run()

--- a/RGBMatrixEmulator/adapters/browser_adapter/request_handlers/__init__.py
+++ b/RGBMatrixEmulator/adapters/browser_adapter/request_handlers/__init__.py
@@ -5,3 +5,6 @@ from RGBMatrixEmulator.adapters.browser_adapter.request_handlers.image import (
 from RGBMatrixEmulator.adapters.browser_adapter.request_handlers.image_web_socket import (
     ImageWebSocketHandler,
 )
+from RGBMatrixEmulator.adapters.browser_adapter.request_handlers.single_file import (
+    SingleFileHandler,
+)

--- a/RGBMatrixEmulator/adapters/browser_adapter/request_handlers/single_file.py
+++ b/RGBMatrixEmulator/adapters/browser_adapter/request_handlers/single_file.py
@@ -1,0 +1,17 @@
+import os
+import tornado.web
+
+
+class SingleFileHandler(tornado.web.RequestHandler):
+    def initialize(self, file_path):
+        self.file_path = file_path
+
+    async def get(self):
+        if not os.path.exists(self.file_path):
+            self.set_status(404)
+            return
+
+        self.set_header("Content-Type", "image/x-icon")
+
+        with open(self.file_path, "rb") as f:
+            self.write(f.read())

--- a/RGBMatrixEmulator/adapters/browser_adapter/server.py
+++ b/RGBMatrixEmulator/adapters/browser_adapter/server.py
@@ -5,7 +5,7 @@ import threading
 import tornado.web
 import tornado.ioloop
 
-from os import path
+from pathlib import Path
 from tornado.platform.asyncio import AnyThreadEventLoopPolicy
 
 from RGBMatrixEmulator.adapters.browser_adapter.request_handlers import *
@@ -30,14 +30,20 @@ class Server:
             ImageWebSocketHandler.register_adapter(self.adapter)
             ImageHandler.register_adapter(self.adapter)
 
-            script_path = path.dirname(path.realpath(__file__))
-            asset_path = path.normpath(script_path + "/static/assets/")
+            script_path = Path(__file__).resolve().parent
+            asset_path = script_path / "static" / "assets"
 
             self.app = tornado.web.Application(
                 [
                     (r"/websocket", ImageWebSocketHandler),
                     (r"/image", ImageHandler),
                     (r"/", MainHandler),
+                    # Icons are served by a specific handler to allow custom icons at arbitrary filepaths
+                    (
+                        r"/assets/icon.ico",
+                        SingleFileHandler,
+                        {"file_path": adapter.icon_path},
+                    ),
                     (
                         r"/assets/(.*)",
                         tornado.web.StaticFileHandler,

--- a/RGBMatrixEmulator/adapters/browser_adapter/static/index.html
+++ b/RGBMatrixEmulator/adapters/browser_adapter/static/index.html
@@ -1,6 +1,6 @@
 <html>
    <head>
-      <title>{{ adapter.emulator_details_text() }}</title>
+      <title>{{ adapter.emulator_title }}</title>
       <link rel="shortcut icon" href="assets/icon.ico">
       <link rel="stylesheet" href="assets/styles.css">
    </head>
@@ -15,7 +15,7 @@
 
       {% if adapter.options.browser.debug_text %}
          <div id="emulatorDetails">
-            <h2>{{ adapter.emulator_details_text() }}</h2>
+            <h2>{{ str(adapter) }}</h2>
             
             <div class="emulatorDetailsTableRow">
                <div id="matrixDetails" class="tableContainer">

--- a/RGBMatrixEmulator/adapters/pygame_adapter.py
+++ b/RGBMatrixEmulator/adapters/pygame_adapter.py
@@ -30,12 +30,12 @@ class PygameAdapter(BaseAdapter):
         if self.loaded:
             return
 
-        Logger.info("Loading {}".format(self.emulator_details_text()))
+        Logger.info("Loading {}".format(self.emulator_title))
         self.__surface = pygame.display.set_mode(self.options.window_size())
         pygame.init()
 
         self.__set_emulator_icon()
-        pygame.display.set_caption(self.emulator_details_text())
+        pygame.display.set_caption(self.emulator_title)
 
         self.loaded = True
 
@@ -57,8 +57,5 @@ class PygameAdapter(BaseAdapter):
                 sys.exit()
 
     def __set_emulator_icon(self):
-        emulator_path = os.path.abspath(os.path.dirname(__file__))
-        icon_path = os.path.join(emulator_path, "..", "icon.png")
-        icon = pygame.image.load(os.path.normpath(icon_path))
-
+        icon = pygame.image.load(self.icon_path)
         pygame.display.set_icon(icon)

--- a/RGBMatrixEmulator/adapters/tkinter_adapter.py
+++ b/RGBMatrixEmulator/adapters/tkinter_adapter.py
@@ -1,5 +1,4 @@
 import tkinter
-import os
 
 from RGBMatrixEmulator.adapters.base import BaseAdapter
 from RGBMatrixEmulator.adapters import PixelStyle
@@ -20,10 +19,10 @@ class TkinterAdapter(BaseAdapter):
         if self.loaded:
             return
 
-        Logger.info("Loading {}".format(self.emulator_details_text()))
+        Logger.info("Loading {}".format(self.emulator_title))
         self.__root = tkinter.Tk()
         self.__set_emulator_icon()
-        self.__root.title(self.emulator_details_text())
+        self.__root.title(self.emulator_title)
 
         window_size = self.options.window_size()
         self.__root.geometry("{}x{}".format(*window_size))
@@ -76,9 +75,5 @@ class TkinterAdapter(BaseAdapter):
         return (start, stop, start + size, stop + size)
 
     def __set_emulator_icon(self):
-        emulator_path = os.path.abspath(os.path.dirname(__file__))
-        raw_icon_path = os.path.join(emulator_path, "..", "icon.png")
-        icon_path = os.path.normpath(raw_icon_path)
-
-        icon = tkinter.PhotoImage(file=icon_path)
+        icon = tkinter.PhotoImage(file=self.icon_path)
         self.__root.tk.call("wm", "iconphoto", self.__root._w, icon)

--- a/RGBMatrixEmulator/adapters/turtle_adapter.py
+++ b/RGBMatrixEmulator/adapters/turtle_adapter.py
@@ -1,4 +1,3 @@
-import os
 import tkinter
 import turtle
 
@@ -29,9 +28,9 @@ class TurtleAdapter(BaseAdapter):
         if self.loaded:
             return
 
-        Logger.info("Loading {}".format(self.emulator_details_text()))
+        Logger.info("Loading {}".format(self.emulator_title))
         turtle.setup(*self.options.window_size())
-        turtle.title(self.emulator_details_text())
+        turtle.title(self.emulator_title)
         self.__pen = turtle.Turtle(visible=False)
         self.__screen = self.__pen.getscreen()
         self.__set_emulator_icon()
@@ -89,9 +88,5 @@ class TurtleAdapter(BaseAdapter):
         self.__pen.pendown()
 
     def __set_emulator_icon(self):
-        emulator_path = os.path.abspath(os.path.dirname(__file__))
-        raw_icon_path = os.path.join(emulator_path, "..", "icon.png")
-        icon_path = os.path.normpath(raw_icon_path)
-
-        icon_image = tkinter.Image("photo", file=icon_path)
+        icon_image = tkinter.Image("photo", file=self.icon_path)
         self.__screen._root.iconphoto(True, icon_image)

--- a/RGBMatrixEmulator/emulation/options.py
+++ b/RGBMatrixEmulator/emulation/options.py
@@ -96,6 +96,8 @@ Defaulting to "{}"...
         self.pixel_outline = emulator_config.DEFAULT_CONFIG["pixel_outline"]
         self.pixel_outline = emulator_config.pixel_outline
         self.browser = emulator_config.browser
+        self.emulator_title = emulator_config.emulator_title
+        self.icon_path = emulator_config.icon_path
 
         if emulator_config.suppress_font_warnings:
             import bdfparser
@@ -123,6 +125,8 @@ class RGBMatrixEmulatorConfig:
         "pixel_style": "square",
         "pixel_glow": 6,
         "display_adapter": "browser",
+        "icon_path": None,
+        "emulator_title": None,
         "suppress_font_warnings": False,
         "suppress_adapter_load_errors": False,
         "browser": {


### PR DESCRIPTION
Adds ability to customize emulator icon and title text across adapters

<img width="564" height="226" alt="white-label-browser" src="https://github.com/user-attachments/assets/9ee5d2d4-7e0c-44f6-bf2c-0ccab1c66c12" />
<img width="788" height="246" alt="white-label-pygame" src="https://github.com/user-attachments/assets/d8e87504-8986-45c4-ac57-a91a4152c70f" />
