### PR TITLE
Add public-facing types to graphics and canvas APIs

### DIFF
--- a/RGBMatrixEmulator/adapters/tkinter_adapter.py
+++ b/RGBMatrixEmulator/adapters/tkinter_adapter.py
@@ -45,7 +45,9 @@ class TkinterAdapter(BaseAdapter):
             for col, pixel in enumerate(pixel_row):
                 shape_id = self.__pixels[row][col]
 
-                self.__canvas.itemconfig(shape_id, fill=Color.to_hex(tuple(pixel)))
+                self.__canvas.itemconfig(
+                    shape_id, fill=("#%02x%02x%02x" % tuple(pixel))
+                )
 
         self.__canvas.pack()
         self.__root.update()

--- a/RGBMatrixEmulator/adapters/turtle_adapter.py
+++ b/RGBMatrixEmulator/adapters/turtle_adapter.py
@@ -34,7 +34,7 @@ class TurtleAdapter(BaseAdapter):
         self.__pen = turtle.Turtle(visible=False)
         self.__screen = self.__pen.getscreen()
         self.__set_emulator_icon()
-        self.__screen.bgcolor(Color.BLACK())
+        self.__screen.bgcolor((0, 0, 0))
         turtle.tracer(0, 0)
         turtle.colormode(255)
 

--- a/RGBMatrixEmulator/emulation/canvas.py
+++ b/RGBMatrixEmulator/emulation/canvas.py
@@ -1,10 +1,12 @@
+from typing import Any
+
 import numpy as np
 from PIL import Image, ImageEnhance
-from RGBMatrixEmulator.graphics.color import Color
+from RGBMatrixEmulator.emulation.options import RGBMatrixOptions
 
 
 class Canvas:
-    def __init__(self, options):
+    def __init__(self, options: RGBMatrixOptions) -> None:
         self.options = options
 
         self.width = options.cols * options.chain_length
@@ -21,36 +23,42 @@ class Canvas:
 
         self.display_adapter.load_emulator_window()
 
-    def Clear(self):
+    def Clear(self) -> None:
         self.__pixels = np.full(
-            self.__pdims, self.__create_pixel(Color.BLACK()), dtype=np.uint8
+            self.__pdims, self.__create_pixel((0, 0, 0)), dtype=np.uint8
         )
 
-    def Fill(self, r, g, b):
+    def Fill(self, r: int, g: int, b: int) -> None:
         self.__pixels = np.full(
             self.__pdims, self.__create_pixel((r, g, b)), dtype=np.uint8
         )
 
-    def SetPixel(self, x, y, r, g, b):
+    def SetPixel(self, x: int, y: int, r: int, g: int, b: int) -> None:
         if self.__pixel_out_of_bounds(x, y):
             return
 
         self.__pixels[int(y)][int(x)] = self.__create_pixel((r, g, b))
 
-    def SetImage(self, image, offset_x=0, offset_y=0, *other):
+    def SetImage(
+        self,
+        image: Image.Image,
+        offset_x: int = 0,
+        offset_y: int = 0,
+        unsafe: bool = True,
+    ) -> None:
         enhancer = ImageEnhance.Brightness(image)
         image = enhancer.enhance(self.brightness / 100.0)
 
         original = Image.fromarray(self.__pixels, "RGB")
         original.paste(image, (offset_x, offset_y))
-        self.__pixels = np.copy(original)
+        self.__pixels = np.copy(original)  # type: ignore
 
     @property
-    def brightness(self):
+    def brightness(self) -> int:
         return self.options.brightness
 
     @brightness.setter
-    def brightness(self, value):
+    def brightness(self, value: int) -> None:
         if not isinstance(value, (int, float)):
             raise ValueError(f"brightness must be a numeric value, received '{value}'")
         elif value < 0 or value > 100:
@@ -61,7 +69,7 @@ class Canvas:
         self.options.brightness = value
 
     def __create_pixel(self, pixel):
-        return Color.adjust_brightness(tuple(pixel), self.brightness / 100.0)
+        return __adjust_brightness(tuple(pixel), self.brightness / 100.0)
 
     def __pixel_out_of_bounds(self, x, y):
         if x < 0 or x >= self.width:
@@ -73,8 +81,15 @@ class Canvas:
         return False
 
     # These are delegated to the display adapter to handle specific implementation.
-    def draw_to_screen(self):
+    def draw_to_screen(self) -> None:
         self.display_adapter.draw_to_screen(self.__pixels)
 
-    def check_for_quit_event(self):
+    def check_for_quit_event(self) -> None:
         self.display_adapter.check_for_quit_event()
+
+
+def __adjust_brightness(pixel, alpha, to_int=False):
+    if to_int:
+        return tuple(int(channel) for channel in pixel)
+
+    return tuple(channel * alpha for channel in pixel)

--- a/RGBMatrixEmulator/emulation/matrix.py
+++ b/RGBMatrixEmulator/emulation/matrix.py
@@ -1,59 +1,66 @@
+from PIL import Image
+
 from RGBMatrixEmulator.emulation.canvas import Canvas
+from RGBMatrixEmulator.emulation.options import RGBMatrixOptions
 
 
 class RGBMatrix:
-    def __init__(self, options={}):
+    def __init__(self, options: RGBMatrixOptions = RGBMatrixOptions()) -> None:
         self.options = options
 
         self.width = options.cols * options.chain_length
         self.height = options.rows * options.parallel
 
-        self.canvas = None
-
-    def CreateFrameCanvas(self):
+    def CreateFrameCanvas(self) -> Canvas:
         self.canvas = Canvas(options=self.options)
 
         return self.canvas
 
     # TODO: framerate_fraction support not yet implemented
     # https://github.com/hzeller/rpi-rgb-led-matrix/commit/f88355e46faafb9de7f1e59dd258ab36c7e7b097
-    def SwapOnVSync(self, canvas, *other):
+    def SwapOnVSync(self, canvas: Canvas, framerate_fraction: int = 1) -> Canvas:
         canvas.check_for_quit_event()
         canvas.draw_to_screen()
         self.canvas = canvas
 
         return self.canvas
 
-    def Clear(self):
+    def Clear(self) -> None:
         self.__sync_canvas()
         self.canvas.Clear()
         self.SwapOnVSync(self.canvas)
 
-    def Fill(self, r, g, b):
+    def Fill(self, r: int, g: int, b: int) -> None:
         self.__sync_canvas()
         self.canvas.Fill(r, g, b)
         self.SwapOnVSync(self.canvas)
 
-    def SetPixel(self, x, y, r, g, b):
+    def SetPixel(self, x: int, y: int, r: int, g: int, b: int) -> None:
         self.__sync_canvas()
         self.canvas.SetPixel(x, y, r, g, b)
         self.SwapOnVSync(self.canvas)
 
-    def SetImage(self, image, offset_x=0, offset_y=0, *other):
+    def SetImage(
+        self,
+        image: Image.Image,
+        offset_x: int = 0,
+        offset_y: int = 0,
+        unsafe: bool = True,
+    ) -> None:
         self.__sync_canvas()
-        self.canvas.SetImage(image, offset_x, offset_y, *other)
+        self.canvas.SetImage(image, offset_x, offset_y, unsafe)
         self.SwapOnVSync(self.canvas)
 
-    def __sync_canvas(self):
+    def __sync_canvas(self) -> None:
         if not self.canvas:
             self.canvas = Canvas(options=self.options)
 
     @property
-    def brightness(self):
+    def brightness(self) -> int:
         return self.options.brightness
 
     @brightness.setter
-    def brightness(self, value):
+    def brightness(self, value: int) -> None:
         if not isinstance(value, (int, float)):
             raise ValueError(f"brightness must be a numeric value, received '{value}'")
         elif value < 0 or value > 100:

--- a/RGBMatrixEmulator/emulation/options.py
+++ b/RGBMatrixEmulator/emulation/options.py
@@ -2,7 +2,7 @@ from RGBMatrixEmulator.internal.emulator_config import RGBMatrixEmulatorConfig
 
 
 class RGBMatrixOptions:
-    def __init__(self):
+    def __init__(self) -> None:
         self.hardware_mapping = "EMULATED"
         self.rows = 32
         self.cols = 32
@@ -35,13 +35,13 @@ class RGBMatrixOptions:
         # Pi5 Adapter
         self.pi5 = emulator_config.pi5
 
-    def window_size(self):
+    def window_size(self) -> tuple[int, int]:
         return (
             self.cols * self.pixel_size * self.chain_length,
             self.rows * self.pixel_size * self.parallel,
         )
 
-    def window_size_str(self, pixel_text=""):
+    def window_size_str(self, pixel_text: str = "") -> str:
         width, height = self.window_size()
 
         return f"{width} x {height} {pixel_text}"

--- a/RGBMatrixEmulator/graphics/__init__.py
+++ b/RGBMatrixEmulator/graphics/__init__.py
@@ -1,9 +1,11 @@
 from functools import wraps
 from inspect import signature
 
+from RGBMatrixEmulator.emulation.canvas import Canvas
 from RGBMatrixEmulator.graphics.color import Color
 from RGBMatrixEmulator.graphics.font import Font
 
+__all__ = ["Color", "Font", "DrawText", "DrawLine", "DrawCircle"]
 
 def validate_color(func):
     """
@@ -34,11 +36,13 @@ def validate_color(func):
 
 
 @validate_color
-def DrawText(canvas, font, x, y, color, text):
+def DrawText(
+    canvas: Canvas, font: Font, x: int, y: int, color: Color, text: str
+) -> int:
     # Early return for empty string prevents bugs in bdfparser library
     # and makes good sense anyway
     if len(text) == 0:
-        return
+        return 0
 
     # Support multiple spacings based on device width
     character_widths = [__actual_width(font, letter) for letter in text]
@@ -82,7 +86,7 @@ def DrawText(canvas, font, x, y, color, text):
 
 
 @validate_color
-def DrawLine(canvas, x1, y1, x2, y2, color):
+def DrawLine(canvas: Canvas, x1: int, y1: int, x2: int, y2: int, color: Color) -> None:
     int_points = __coerce_int(x1, y1, x2, y2)
     rows, cols = __line(*int_points)
 
@@ -91,9 +95,9 @@ def DrawLine(canvas, x1, y1, x2, y2, color):
 
 
 @validate_color
-def DrawCircle(canvas, x, y, r, color):
-    int_points = __coerce_int(x, y)
-    rows, cols = __circle_perimeter(*int_points, r)
+def DrawCircle(canvas: Canvas, x: int, y: int, r: int, color: Color):
+    x, y = __coerce_int(x, y)
+    rows, cols = __circle_perimeter(x, y, r)
 
     for point in zip(rows, cols):
         canvas.SetPixel(*point, color.red, color.green, color.blue)
@@ -112,7 +116,7 @@ def __actual_width(font, letter):
     return font.CharacterWidth(font.default_character.cp())
 
 
-def __coerce_int(*values):
+def __coerce_int(*values) -> list[int]:
     return [int(value) for value in values]
 
 

--- a/RGBMatrixEmulator/graphics/color.py
+++ b/RGBMatrixEmulator/graphics/color.py
@@ -1,5 +1,5 @@
 class Color:
-    def __init__(self, r=0, g=0, b=0):
+    def __init__(self, r: int = 0, g: int = 0, b: int = 0) -> None:
         # Simulate Cython uint8_t bounds checking
         for c in (r, g, b):
             if c > 255:
@@ -11,30 +11,3 @@ class Color:
         self.red = r
         self.green = g
         self.blue = b
-
-    @classmethod
-    def adjust_brightness(cls, pixel, alpha, to_int=False):
-        if to_int:
-            return tuple(int(channel) for channel in pixel)
-
-        return tuple(channel * alpha for channel in pixel)
-
-    @classmethod
-    def to_hex(cls, pixel):
-        return "#%02x%02x%02x" % pixel
-
-    @classmethod
-    def BLACK(cls):
-        return (0, 0, 0)
-
-    @classmethod
-    def RED(cls):
-        return (255, 0, 0)
-
-    @classmethod
-    def GREEN(cls):
-        return (0, 255, 0)
-
-    @classmethod
-    def BLUE(cls):
-        return (0, 0, 255)

--- a/RGBMatrixEmulator/graphics/font.py
+++ b/RGBMatrixEmulator/graphics/font.py
@@ -2,12 +2,11 @@ import bdfparser
 
 
 class Font:
-    def __init__(self):
-        self.bdf_font = None
-        self.headers = {}
-        self.spacing = {}
+    bdf_font: bdfparser.Font
+    headers: dict
+    props: dict
 
-    def LoadFont(self, path):
+    def LoadFont(self, path: str) -> None:
         self.bdf_font = bdfparser.Font(path)
         self.headers = self.bdf_font.headers
         self.props = self.bdf_font.props
@@ -16,7 +15,7 @@ class Font:
         # Cache this for use later so we don't have to constantly look it up
         self.default_character = self.bdf_font.glyphbycp(0xFFFD)
 
-    def CharacterWidth(self, char):
+    def CharacterWidth(self, char: str) -> int:
         # Missing glyphs return 0 width in rpi-rgb-led-matrix
         if self.bdf_font == None or not self.bdf_font.glyphbycp(char):
             return 0
@@ -24,13 +23,13 @@ class Font:
         return self.bdf_font.glyphbycp(char).meta["dwx0"]
 
     @property
-    def height(self):
+    def height(self) -> int:
         if self.bdf_font is None:
             return -1
         return self.headers["fbby"]
 
     @property
-    def baseline(self):
+    def baseline(self) -> int:
         if self.bdf_font is None:
             return 0
         return self.headers["fbby"] + self.headers["fbbyoff"]

--- a/RGBMatrixEmulator/internal/emulator_config.py
+++ b/RGBMatrixEmulator/internal/emulator_config.py
@@ -1,4 +1,6 @@
 import json, os, pprint
+from typing import Optional
+
 
 from RGBMatrixEmulator.internal.pixel_style import PixelStyle
 from RGBMatrixEmulator.internal.adapter_loader import AdapterLoader
@@ -41,6 +43,18 @@ class RGBMatrixEmulatorConfig:
         },
         "log_level": "info",
     }
+
+    pixel_outline: int
+    pixel_size: int
+    pixel_style: str
+    pixel_glow: int
+    allow_adapter_fallback: bool
+    icon_path: Optional[str]
+    emulator_title: Optional[str]
+    suppress_font_warnings: bool
+    log_level: str
+    pi5: "ChildConfig"
+    browser: "ChildConfig"
 
     def __init__(self):
         self.config = self.__load_config()
@@ -87,9 +101,9 @@ class RGBMatrixEmulatorConfig:
                 self.pixel_style = PixelStyle.DEFAULT
                 Logger.warning(
                     """
-"{}" pixel style option is not supported by adapter "{}". 
+"{}" pixel style option is not supported by adapter "{}".
 Supported pixel styles for this adapter are {}
-                                                              
+
 Defaulting to "{}"...
 """.format(
                         self.pixel_style.lower(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ LICENSE = "docs/LICENSE"
 "RGBMatrixEmulator/icon.png" = "RGBMatrixEmulator/icon.png"
 "RGBMatrixEmulator/adapters/browser_adapter/static/index.html" = "RGBMatrixEmulator/index.html"
 "RGBMatrixEmulator/adapters/browser_adapter/static/assets" = "RGBMatrixEmulator"
+"RGBMatrixEmulator/py.typed" = "RGBMatrixEmulator/py.typed"
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
This lets downstream code get better typechecking using an incantion like this:

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from RGBMatrixEmulator.emulation.canvas import Canvas
    from RGBMatrixEmulator import graphics
```