### PR TITLE
Allow more pixel styles in raw adaptor

### DIFF
--- a/RGBMatrixEmulator/adapters/raw_adapter/__init__.py
+++ b/RGBMatrixEmulator/adapters/raw_adapter/__init__.py
@@ -1,11 +1,14 @@
 from RGBMatrixEmulator.adapters.base import BaseAdapter
-
-from PIL import Image
-
-import numpy as np
+from RGBMatrixEmulator.internal.pixel_style import PixelStyle
 
 
 class RawAdapter(BaseAdapter):
+    SUPPORTED_PIXEL_STYLES = [
+        PixelStyle.SQUARE,
+        PixelStyle.CIRCLE,
+        PixelStyle.REAL,
+    ]
+
     MAX_FRAMES_STORED = 128
     DEFAULT_MAX_FRAME = -1  # Never halts
 
@@ -29,7 +32,7 @@ class RawAdapter(BaseAdapter):
         pass
 
     def _dump_screenshot(self, path):
-        image = Image.fromarray(np.array(self._last_frame(), dtype="uint8"), "RGB")
+        image = self._get_masked_image(self._last_frame())
         image.save(path)
 
     def _last_frame(self):

--- a/test/test_config.json
+++ b/test/test_config.json
@@ -1,7 +1,7 @@
 {
     "_comment": "This config is used specifically to test RGBME via the raw adapter",
     "pixel_outline": 0,
-    "pixel_size": 16,
+    "pixel_size": 1,
     "pixel_style": "square",
     "pixel_glow": 6,
     "display_adapter": "raw",


### PR DESCRIPTION
I'm working on an action which would post a preview any time we change the colors in mlb-led-scoreboard:
https://github.com/WardBrian/mlb-led-scoreboard/pull/21

This helps make it more true-to-life