### PR TITLE
Make display adapter installation optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,39 @@
 
 ## Installation
 
-`RGBMatrixEmulator` is in the [Python Package Index (PyPI)](http://pypi.python.org/pypi/RGBMatrixEmulator/).
-Installing with ``pip`` is recommended for all systems.
+`RGBMatrixEmulator` is in the [Python Package Index (PyPI)](http://pypi.python.org/pypi/RGBMatrixEmulator/). Installing with `pip` is recommended for all systems.
 
 ```sh
 pip install RGBMatrixEmulator
 ```
 
-### Experimental `pi5` Adapter
+The base installation includes the following display adapters:
 
-To use the experimental `pi5` adapter, you can install the optional adapter as follows. This installation is only valid for Raspberry Pi 5 hardware.
+* `browser` (default)
+* `terminal`
+* `tkinter`
+* `turtle`
+* `raw`
+
+For more information on display adapters, see the [Display Adapters](#display-adapters) section.
+
+### Optional Adapters
+
+The following adapters are supported but not installed by default.
+
+* `sixel`
+* `pygame`
+* `pi5` (experimental)
+
+You can install optional adapters via `pip`:
 
 ```sh
+pip install RGBMatrixEmulator[sixel]
+pip install RGBMatrixEmulator[pygame]
 pip install RGBMatrixEmulator[pi5]
+
+# All optional adapters at once
+pip install RGBMatrixEmulator[sixel,pygame,pi5]
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,17 +33,21 @@ classifiers = [
 ]
 dependencies = [
     "bdfparser<=2.2.0",
-    "libsixel-python>=0.5.0",
     "numpy>=1.2.0",
     "Pillow>=10.0.1",
-    "pygame>=2.0.1,<3",
-    "tornado>=6.5.5"
+    "tornado>=6.5.5",
 ]
 
 [project.scripts]
 rgbme = "RGBMatrixEmulator.cli:run_cli"
 
 [project.optional-dependencies]
+pygame = [
+    "pygame>=2.0.1,<3",
+]
+sixel = [
+    "libsixel-python>=0.5.0",
+]
 pi5 = [
     "Adafruit-Blinka-Raspberry-Pi5-Piomatter>=1.0.0; python_version>='3.11'",
     "adafruit-blinka>=8.0.0; python_version>='3.11'",

--- a/test/reference.py
+++ b/test/reference.py
@@ -13,8 +13,6 @@ from context import (
     TestConfigContext,
 )
 
-os.environ["RGBME_SUPPRESS_ADAPTER_LOAD_ERRORS"] = "true"
-
 sys.path.append(os.path.abspath(os.path.join(__file__, "..", "..")))
 
 import samples

--- a/uv.lock
+++ b/uv.lock
@@ -597,11 +597,9 @@ name = "rgbmatrixemulator"
 source = { editable = "." }
 dependencies = [
     { name = "bdfparser" },
-    { name = "libsixel-python" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
-    { name = "pygame" },
     { name = "tornado" },
 ]
 
@@ -609,6 +607,12 @@ dependencies = [
 pi5 = [
     { name = "adafruit-blinka", marker = "python_full_version >= '3.11'" },
     { name = "adafruit-blinka-raspberry-pi5-piomatter", marker = "python_full_version >= '3.11'" },
+]
+pygame = [
+    { name = "pygame" },
+]
+sixel = [
+    { name = "libsixel-python" },
 ]
 
 [package.dev-dependencies]
@@ -622,13 +626,13 @@ requires-dist = [
     { name = "adafruit-blinka", marker = "python_full_version >= '3.11' and extra == 'pi5'", specifier = ">=8.0.0" },
     { name = "adafruit-blinka-raspberry-pi5-piomatter", marker = "python_full_version >= '3.11' and extra == 'pi5'", specifier = ">=1.0.0" },
     { name = "bdfparser", specifier = "<=2.2.0" },
-    { name = "libsixel-python", specifier = ">=0.5.0" },
+    { name = "libsixel-python", marker = "extra == 'sixel'", specifier = ">=0.5.0" },
     { name = "numpy", specifier = ">=1.2.0" },
     { name = "pillow", specifier = ">=10.0.1" },
-    { name = "pygame", specifier = ">=2.0.1,<3" },
+    { name = "pygame", marker = "extra == 'pygame'", specifier = ">=2.0.1,<3" },
     { name = "tornado", specifier = ">=6.5.5" },
 ]
-provides-extras = ["pi5"]
+provides-extras = ["pi5", "pygame", "sixel"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Makes `pygame` and `sixel` adapter installation optional to reduce dependencies

Mitigates #128 