### PR TITLE
Reexport RGBMatrix, RGBMatrixOptions and __version__

### DIFF
--- a/RGBMatrixEmulator/__init__.py
+++ b/RGBMatrixEmulator/__init__.py
@@ -3,3 +3,9 @@ from RGBMatrixEmulator.emulation.matrix import RGBMatrix
 from RGBMatrixEmulator.emulation.options import RGBMatrixOptions
 
 from RGBMatrixEmulator.version import __version__
+
+__all__ = [
+    "RGBMatrix",
+    "RGBMatrixOptions",
+    "__version__",
+]


### PR DESCRIPTION
Explicitly declare public API to improve static analysis and tooling support.

The README states:

    from RGBMatrixEmulator import RGBMatrix, RGBMatrixOptions

So this should be really supported and not only work "by accident".

Note that I didn't include `"Color", "Font", "DrawText", "DrawLine", "DrawCircle"` from `graphics.*` as these classes aren't exported in the `rgbmatrix` package either, so I guess the import statement `from RGBMatrixEmulator.graphics import *` should rather be removed (for compatibility with `rgbmatrix`), but this would break backward compatibility.